### PR TITLE
Allow zbl code input

### DIFF
--- a/src/zb_links/api/link/helpers/link_helpers.py
+++ b/src/zb_links/api/link/helpers/link_helpers.py
@@ -188,3 +188,29 @@ def get_links_from_mscs(msc_val):
     link_list_msc = [link for link in link_query.all()]
 
     return link_list_msc
+
+
+def get_id_type(doc_id):
+    """
+
+    Parameters
+    ----------
+    doc_id : str or int (as string)
+        represents the DE number (document) resp. the Zbl code (zbl_id)
+        of a document in math_documents
+
+    Returns
+    -------
+    doc_type : str
+        'de_number' if the DE number is given
+        'zbl_id' if the Zbl code is given.
+
+    """
+    doc_type = None
+    try:
+        int(doc_id)
+        doc_type = "de_number"
+    except ValueError:
+        doc_type = "zbl_code"
+
+    return doc_type

--- a/src/zb_links/api/link/helpers/target_helpers.py
+++ b/src/zb_links/api/link/helpers/target_helpers.py
@@ -1,0 +1,27 @@
+from zb_links.db.models import ZBTarget
+
+
+def get_de_from_zbl_id(doc_id):
+    """
+
+    Parameters
+    ----------
+    doc_id : str or int (as string)
+        represents the DE number (document) resp. the Zbl code (zbl_id)
+        of a document in math_documents
+
+    Returns
+    -------
+    de_val : int
+        the DE number corresponding to the doc_id
+
+    """
+    de_val = None
+    try:
+        de_val = int(doc_id)
+    except ValueError:
+        zb_obj = ZBTarget.query.filter_by(zbl_id=doc_id).first()
+        if zb_obj:
+            de_val = zb_obj.id
+
+    return de_val

--- a/src/zb_links/api/link/links.py
+++ b/src/zb_links/api/link/links.py
@@ -28,7 +28,7 @@ search_by_arguments.add_argument("authors", type=str, required=False)
 
 search_by_arguments.add_argument("MSC code", type=str, required=False)
 
-search_by_arguments.add_argument("DE number", type=int, required=False)
+search_by_arguments.add_argument("DE number", type=str, required=False)
 
 
 @api.expect(search_by_arguments)
@@ -89,16 +89,13 @@ class LinkCollection(Resource):
 
         if doc_id:
             id_type = link_helpers.get_id_type(doc_id)
+            if id_type == "zbl_code":
+                doc_id = target_helpers.get_de_from_zbl_id(doc_id)
 
             # get all links corresponding to document input
-            if id_type == "zbl_code":
-                link_doc_id = Link.query.filter_by(
-                    zbl_id=doc_id, matched_by="LinksApi"
-                ).all()
-            if id_type == "de_number":
-                link_doc_id = Link.query.filter_by(
-                    document=doc_id, matched_by="LinksApi"
-                ).all()
+            link_doc_id = Link.query.filter_by(
+                document=doc_id, matched_by="LinksApi"
+            ).all()
             link_set = link_helpers.update_set_by_intersect(
                 link_set, set(link_doc_id)
             )
@@ -149,13 +146,11 @@ class LinkItem(Resource):
         return_link = None
         id_type = link_helpers.get_id_type(doc_id)
         if id_type == "zbl_code":
-            return_link = Link.query.filter_by(
-                zbl_id=doc_id, external_id=source_val, type=partner_name
-            ).first()
-        if id_type == "de_number":
-            return_link = Link.query.filter_by(
-                document=doc_id, external_id=source_val, type=partner_name
-            ).first()
+            doc_id = target_helpers.get_de_from_zbl_id(doc_id)
+
+        return_link = Link.query.filter_by(
+            document=doc_id, external_id=source_val, type=partner_name
+        ).first()
 
         return_display = []
         if return_link:

--- a/src/zb_links/api/link/links.py
+++ b/src/zb_links/api/link/links.py
@@ -42,8 +42,8 @@ class LinkCollection(Resource):
                 "(multiple inputs with ; as delimiter)"
             },
             "DE number": {
-                "description": "Ex: 3273551 (available in the "
-                "bibtex of each document at https://zbmath.org/)"
+                "description": "Ex: 3273551 (DE number)"
+                               " or 0171.38503 (Zbl code)"
             },
             "MSC code": {
                 "description": "Ex: 33-00 "
@@ -125,9 +125,8 @@ class LinkItem(Resource):
     @api.doc(
         params={
             "DE number": {
-                "description": "Ex: 3273551 (available "
-                "in the bibtex of each document at "
-                "https://zbmath.org/)"
+                "description": "Ex: 3273551 (DE number)"
+                               " or 0171.38503 (Zbl code)"
             },
             "external id": {
                 "description": "Ex (DLMF): 11.14#I1.i1.p1"
@@ -163,9 +162,8 @@ class LinkItem(Resource):
     @api.doc(
         params={
             "DE number": {
-                "description": "Ex: 3273551 (available "
-                "in the bibtex of each document at "
-                "https://zbmath.org/)"
+                "description": "Ex: 3273551 (DE number)"
+                               " or 0171.38503 (Zbl code)"
             },
             "external id": {
                 "description": "Ex (DLMF): 11.14#I1.i1.p1"

--- a/src/zb_links/api/link/links.py
+++ b/src/zb_links/api/link/links.py
@@ -43,7 +43,7 @@ class LinkCollection(Resource):
             },
             "DE number": {
                 "description": "Ex: 3273551 (DE number)"
-                               " or 0171.38503 (Zbl code)"
+                " or 0171.38503 (Zbl code)"
             },
             "MSC code": {
                 "description": "Ex: 33-00 "
@@ -126,7 +126,7 @@ class LinkItem(Resource):
         params={
             "DE number": {
                 "description": "Ex: 3273551 (DE number)"
-                               " or 0171.38503 (Zbl code)"
+                " or 0171.38503 (Zbl code)"
             },
             "external id": {
                 "description": "Ex (DLMF): 11.14#I1.i1.p1"
@@ -163,7 +163,7 @@ class LinkItem(Resource):
         params={
             "DE number": {
                 "description": "Ex: 3273551 (DE number)"
-                               " or 0171.38503 (Zbl code)"
+                " or 0171.38503 (Zbl code)"
             },
             "external id": {
                 "description": "Ex (DLMF): 11.14#I1.i1.p1"

--- a/tests/api/link/links_test.py
+++ b/tests/api/link/links_test.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlencode
 import os
 
+from zb_links.api.link.helpers import target_helpers
 from zb_links.db.models import Link, db
 
 
@@ -58,6 +59,49 @@ def test_post_link(client):
 
     # delete test entry
     link_query = Link.query.filter_by(document=document,
+                                      external_id=external_id,
+                                      type=partner_name,
+                                      )
+    link_query.delete()
+
+    db.session.commit()
+
+
+def test_post_link_with_zbl(client):
+    zbl_id = '1234.98765'
+    external_id = "11.14#I1.i1.p1"
+    partner_name = "DLMF"
+
+    de_val = target_helpers.get_de_from_zbl_id(zbl_id)
+
+    link_query = Link.query.filter_by(document=de_val,
+                                      external_id=external_id,
+                                      type=partner_name,
+                                      )
+    link_to_add = link_query.all()
+
+    assert len(link_to_add) == 0, "test link to create is not unique"
+
+    json = {"DE number": de_val,
+            "external id": external_id,
+            "partner": partner_name}
+    param = urlencode(json)
+    headers = {"X-API-KEY": os.getenv("ZBMATH_API_KEY")}
+    response = client.post(f"/links_api/link/item/?{param}",
+                          headers=headers,
+                          )
+    assert response.status_code == 201
+
+    data = response.json
+    assert data is None
+
+    response = client.get(f"/links_api/link/item/?{param}")
+    data = response.json
+    source: dict = data.get("Source")
+    assert source["Identifier"]["ID"] == external_id
+
+    # delete test entry
+    link_query = Link.query.filter_by(document=de_val,
                                       external_id=external_id,
                                       type=partner_name,
                                       )

--- a/tests/api/link/links_test.py
+++ b/tests/api/link/links_test.py
@@ -5,9 +5,31 @@ from zb_links.api.link.helpers import target_helpers
 from zb_links.db.models import Link, db
 
 
+def test_get_all_links_from_zbl(client):
+
+    json = {"DE number": "0171.38503"}
+    param = urlencode(json)
+    response = client.get(f"/links_api/link/?{param}")
+    assert 200 == response.status_code
+    first_data = response.json[0]
+    assert first_data["Source"]["Identifier"]["ID"] == "11.14#I1.i1.p1"
+
+
 def test_get_link_item(client):
     test_id = "11.14#I1.i1.p1"
     json = {"DE number": 3273551,
+            "external id": test_id,
+            "partner": "DLMF"}
+    param = urlencode(json)
+    response = client.get(f"/links_api/link/item/?{param}")
+    assert 200 == response.status_code
+    data = response.json
+    assert data["Source"]["Identifier"]["ID"] == test_id
+
+
+def test_get_link_item_zbl(client):
+    test_id = "11.14#I1.i1.p1"
+    json = {"DE number": "0171.38503",
             "external id": test_id,
             "partner": "DLMF"}
     param = urlencode(json)

--- a/tests/api/link/links_test.py
+++ b/tests/api/link/links_test.py
@@ -64,3 +64,22 @@ def test_post_link(client):
     link_query.delete()
 
     db.session.commit()
+
+
+def test_post_link_with_bad_zbl(client):
+    zbl_id = '2062.129'
+    external_id = "11.14#I1.i1.p1"
+    partner_name = "DLMF"
+
+    json = {"DE number": zbl_id,
+            "external id": external_id,
+            "partner": partner_name}
+    param = urlencode(json)
+    headers = {"X-API-KEY": os.getenv("ZBMATH_API_KEY")}
+    response = client.post(f"/links_api/link/item/?{param}",
+                          headers=headers,
+                          )
+    assert response.status_code == 422
+
+    data = response.json
+    assert data.get("message")


### PR DESCRIPTION
field 'DE number' input changed to string.  Both Zbl code and DE number are allowed as input.  Type of input is then checked to determine which of two is entered.  Math document (Target) lookup is then done accordingly.