### PR TITLE
get title fixture for tests

### DIFF
--- a/tests/api/link/conftest.py
+++ b/tests/api/link/conftest.py
@@ -2,6 +2,7 @@ import os
 import time
 
 import pytest
+from unittest import mock
 
 from zb_links.app import create_app
 
@@ -17,3 +18,13 @@ app.config['TESTING'] = True
 def client():
     with app.test_client() as client:
         yield client
+
+
+@pytest.fixture(autouse=True)
+def mock_title():
+    with mock.patch(
+            "zb_links.api.link.helpers.dlmf_source_helpers.get_title"
+        ) as title_mock:
+
+        title_mock.return_value = "Asymptotic Approximation"
+        yield title_mock


### PR DESCRIPTION
added a fixture which is used to bypass calls by patch and post to the dlmf website to fetch titles of sections.