### PR TITLE
Bug/partner lower

### DIFF
--- a/src/zb_links/api/link/display.py
+++ b/src/zb_links/api/link/display.py
@@ -119,7 +119,6 @@ def get_display(link_element):
     source_publisher_url = partner_obj.url
     source_publisher_id_scheme = partner_obj.scheme
 
-
     source_obj = Source.query.get(element_source)
     source_id_dict = {
         "ID": source_obj.id,

--- a/src/zb_links/api/link/display.py
+++ b/src/zb_links/api/link/display.py
@@ -5,7 +5,7 @@
 from flask_restx import fields, marshal
 
 from zb_links.api.restx import api
-from zb_links.db.models import Source, ZBTarget
+from zb_links.db.models import Partner, Source, ZBTarget
 
 object_id_info = api.model(
     "identifier",
@@ -112,12 +112,13 @@ def get_display(link_element):
     element_link_provider = link_element.created_by
     element_relationship_type = None
 
-    source_publisher_url = ""
-    source_publisher_id_scheme = ""
-    partner = link_element.type
-    if partner == "DLMF":
-        source_publisher_url = "https://dlmf.nist.gov/"
-        source_publisher_id_scheme = "name of partner"
+    partner_id = link_element.type
+    partner_obj = Partner.query.get(partner_id)
+    partner_display = partner_obj.display_name
+
+    source_publisher_url = partner_obj.url
+    source_publisher_id_scheme = partner_obj.scheme
+
 
     source_obj = Source.query.get(element_source)
     source_id_dict = {
@@ -127,12 +128,12 @@ def get_display(link_element):
     }
     source_name_dict = {"Name": source_obj.type}
     source_publisher_identifier_dict = {
-        "ID": partner,
+        "ID": partner_id,
         "IDScheme": source_publisher_id_scheme,
         "IDURL": source_publisher_url,
     }
     source_publisher_dict = {
-        "Name": partner,
+        "Name": partner_display,
         "Identifier": marshal(
             source_publisher_identifier_dict, object_id_info
         ),

--- a/src/zb_links/api/link/helpers/source_helpers.py
+++ b/src/zb_links/api/link/helpers/source_helpers.py
@@ -2,7 +2,7 @@ from zb_links.api.link.helpers import dlmf_source_helpers, helpers
 from zb_links.db.models import Source, db
 
 Sources = {
-    "DLMF": {
+    "dlmf": {
         "id_scheme": "DLMF scheme",
         "url_prefix": "https://dlmf.nist.gov/",
         "type": "DLMF reference",
@@ -11,7 +11,7 @@ Sources = {
 
 
 def create_new_source(source_val, source_name, title_name=None):
-    if source_name == "DLMF":
+    if source_name == "dlmf":
         if not title_name:
             title_name = dlmf_source_helpers.get_title(source_val)
 

--- a/src/zb_links/api/link/links.py
+++ b/src/zb_links/api/link/links.py
@@ -157,7 +157,7 @@ class LinkItem(Resource):
         args = request.args
         doc_id = args[arg_names["document"]].strip()
         source_val = args[arg_names["link_ext_id"]]
-        partner_name = args[arg_names["link_partner"]]
+        partner_name = args[arg_names["link_partner"]].lower()
 
         return_link = None
         doc_id = target_helpers.get_de_from_input(doc_id)
@@ -184,7 +184,7 @@ class LinkItem(Resource):
         doc_id = target_helpers.get_de_from_input(doc_id)
 
         source_val = args[arg_names["link_ext_id"]]
-        source_name = args[arg_names["link_partner"]]
+        source_name = args[arg_names["link_partner"]].lower()
         title_name = None
         try:
             title_name = args["title"]
@@ -246,7 +246,7 @@ class LinkItem(Resource):
         args = request.args
         link_document = args[arg_names["document"]].strip()
         link_external_id = args[arg_names["link_ext_id"]]
-        link_type = args[arg_names["link_partner"]]
+        link_type = args[arg_names["link_partner"]].lower()
         title_name = None
         try:
             title_name = args["title"]
@@ -349,7 +349,7 @@ class LinkItem(Resource):
         args = request.args
         doc_id = args[arg_names["document"]].strip()
         source_val = args[arg_names["link_ext_id"]]
-        partner_name = args[arg_names["link_partner"]]
+        partner_name = args[arg_names["link_partner"]].lower()
 
         doc_id = target_helpers.get_de_from_input(doc_id)
         link_to_delete_query = Link.query.filter_by(

--- a/src/zb_links/api/link/partners.py
+++ b/src/zb_links/api/link/partners.py
@@ -15,6 +15,9 @@ partner = api.model(
     "Linking partner",
     {
         "name": fields.String(required=True, description="Partner name"),
+        "display_name": fields.String(
+             required=True, description="Partner name as displayed"
+        ),
         "scheme": fields.String(
             required=True,
             description="Schematic followed to establish partner identifier",

--- a/src/zb_links/api/link/partners.py
+++ b/src/zb_links/api/link/partners.py
@@ -67,17 +67,22 @@ class PartnerCollection(Resource):
             return helpers.make_message(422, "Invalid input")
 
         partner_name = partner_to_edit.name
+        partner_display_name = partner_to_edit.display_name
         partner_scheme = partner_to_edit.scheme
         partner_url = partner_to_edit.url
         if "new partner name" in arg_key_list:
-            partner_name = args["new partner name"].lower()
+            partner_display_name = args["new partner name"]
+            partner_name = partner_display_name.lower()
         if "partner id scheme" in arg_key_list:
             partner_scheme = args["partner id scheme"]
         if "partner url" in arg_key_list:
             partner_url = args["partner url"]
 
         data_to_update = dict(
-            name=partner_name, scheme=partner_scheme, url=partner_url
+            name=partner_name,
+            display_name=partner_display_name,
+            scheme=partner_scheme,
+            url=partner_url
         )
 
         partner_query.update(data_to_update)

--- a/src/zb_links/api/link/partners.py
+++ b/src/zb_links/api/link/partners.py
@@ -58,7 +58,7 @@ class PartnerCollection(Resource):
         for a_key in arg_keys:
             arg_key_list.append(a_key)
 
-        partner_name = args["current partner name"]
+        partner_name = args["current partner name"].lower()
 
         partner_query = Partner.query.filter_by(name=partner_name)
         partner_to_edit = Partner.query.get(partner_name)
@@ -70,7 +70,7 @@ class PartnerCollection(Resource):
         partner_scheme = partner_to_edit.scheme
         partner_url = partner_to_edit.url
         if "new partner name" in arg_key_list:
-            partner_name = args["new partner name"]
+            partner_name = args["new partner name"].lower()
         if "partner id scheme" in arg_key_list:
             partner_scheme = args["partner id scheme"]
         if "partner url" in arg_key_list:

--- a/src/zb_links/api/link/partners.py
+++ b/src/zb_links/api/link/partners.py
@@ -82,7 +82,7 @@ class PartnerCollection(Resource):
             name=partner_name,
             display_name=partner_display_name,
             scheme=partner_scheme,
-            url=partner_url
+            url=partner_url,
         )
 
         partner_query.update(data_to_update)

--- a/src/zb_links/api/link/partners.py
+++ b/src/zb_links/api/link/partners.py
@@ -16,7 +16,7 @@ partner = api.model(
     {
         "name": fields.String(required=True, description="Partner name"),
         "display_name": fields.String(
-             required=True, description="Partner name as displayed"
+            required=True, description="Partner name as displayed"
         ),
         "scheme": fields.String(
             required=True,

--- a/src/zb_links/api/link/source.py
+++ b/src/zb_links/api/link/source.py
@@ -26,7 +26,7 @@ class SourceCollection(Resource):
     def get(self):
         """List of links of a given zbMATH partner"""
         args = request.args
-        partner_name = args["partner"]
+        partner_name = args["partner"].lower()
 
         sources = Source.query.filter(Source.partner == partner_name).all()
         display_list = []

--- a/src/zb_links/api/link/statistics_msc.py
+++ b/src/zb_links/api/link/statistics_msc.py
@@ -32,7 +32,7 @@ class MSCCollection(Resource):
     def get(self):
         """Occurrence of primary MSC codes of zbMATH objects"""
         args = request.args
-        partner_name = args["partner"]
+        partner_name = args["partner"].lower()
 
         queries = (
             ZBTarget.query.join(Link, Link.document == ZBTarget.id)

--- a/src/zb_links/api/link/statistics_years.py
+++ b/src/zb_links/api/link/statistics_years.py
@@ -28,7 +28,7 @@ class YearCollection(Resource):
     def get(self):
         """Occurrence of years of publication of zbMATH objects"""
         args = request.args
-        partner_name = args["partner"]
+        partner_name = args["partner"].lower()
 
         queries = (
             ZBTarget.query.join(Link, Link.document == ZBTarget.id)

--- a/src/zb_links/db/models.py
+++ b/src/zb_links/db/models.py
@@ -12,6 +12,7 @@ class Partner(db.Model):
     __table_args__ = {"schema": "zb_links"}
 
     name = db.Column(db.String(), primary_key=True)
+    display_name = db.Column(db.String())
     scheme = db.Column(db.String())
     url = db.Column(db.String())
 
@@ -19,8 +20,9 @@ class Partner(db.Model):
         "Source", backref="partners", cascade="all, delete-orphan"
     )
 
-    def __init__(self, name, scheme, url):
+    def __init__(self, name, display_name, scheme, url):
         self.name = name
+        self.display_name = display_name
         self.scheme = scheme
         self.url = url
 

--- a/src/zb_links/db/seed_db.py
+++ b/src/zb_links/db/seed_db.py
@@ -15,11 +15,12 @@ seedbp = Blueprint("seed", __name__)
 
 @seedbp.cli.command("partner")
 def seed_partner():
-    name = "DLMF"
+    name = "dlmf"
+    display_name = "DLMF"
     scheme = "DLMF scheme"
     url = "https://dlmf.nist.gov/"
 
-    new_partner = Partner(name, scheme, url)
+    new_partner = Partner(name, display_name, scheme, url)
 
     db.session.add(new_partner)
     db.session.commit()
@@ -39,11 +40,11 @@ def seed_source():
         type="DLMF bibliographic entry",
         url="https://dlmf.nist.gov/11.14#I1.i1.p1",
         title=chapter_title,
-        partner="DLMF",
+        partner="dlmf",
     )
 
     # add source to partner
-    partner_obj = Partner.query.filter_by(name="DLMF").first()
+    partner_obj = Partner.query.filter_by(name="dlmf").first()
     partner_obj.sources.append(new_source_entry)
 
     db.session.add(new_source_entry)
@@ -99,7 +100,7 @@ def seed_link():
     new_link = Link(
         document=3273551,
         external_id="11.14#I1.i1.p1",
-        type="DLMF",
+        type="dlmf",
         matched_by="zbmath-links-api",
         matched_by_version="0.2",
         matched_at=dt,

--- a/tests/api/link/links_test.py
+++ b/tests/api/link/links_test.py
@@ -71,7 +71,7 @@ def test_get_link_msc(client):
 def test_post_link(client):
     document = 2062129
     external_id = "11.14#I1.i1.p1"
-    partner_name = "DLMF"
+    partner_name = "dlmf"
 
     link_query = Link.query.filter_by(document=document,
                                       external_id=external_id,
@@ -121,7 +121,7 @@ def test_post_link(client):
 def test_post_link_with_zbl(client):
     zbl_id = "1234.98765"
     external_id = "11.14#I1.i1.p1"
-    partner_name = "DLMF"
+    partner_name = "dlmf"
 
     de_val = target_helpers.get_de_from_input(zbl_id)
 
@@ -173,7 +173,7 @@ def test_post_link_with_zbl(client):
 def test_post_link_with_bad_zbl(client):
     zbl_id = "2062.129"
     external_id = "11.14#I1.i1.p1"
-    partner_name = "DLMF"
+    partner_name = "dlmf"
 
     json = {arg_names["document"]: zbl_id,
             arg_names["link_ext_id"]: external_id,
@@ -192,7 +192,7 @@ def test_post_link_with_bad_zbl(client):
 def test_patch_link_with_empty(client):
     doc_id = 3273551
     external_id = "11.14#I1.i1.p1"
-    partner_name = "DLMF"
+    partner_name = "dlmf"
 
     json_base = {arg_names["document"]: doc_id,
                   arg_names["link_ext_id"]: external_id,
@@ -214,7 +214,7 @@ def test_patch_link_with_empty(client):
 def test_patch_link_with_fake_new(client):
     doc_id = 3273551
     external_id = "11.14#I1.i1.p1"
-    partner_name = "DLMF"
+    partner_name = "dlmf"
 
     json_base = {arg_names["document"]: doc_id,
                   arg_names["link_ext_id"]: external_id,
@@ -237,7 +237,7 @@ def test_patch_link_with_fake_new(client):
 def test_patch_link_with_de(client):
     doc_id = 3273551
     external_id = "11.14#I1.i1.p1"
-    partner_name = "DLMF"
+    partner_name = "dlmf"
 
     de_val = target_helpers.get_de_from_input(doc_id)
 
@@ -281,7 +281,7 @@ def test_patch_link_with_de(client):
 def test_patch_link_with_new_source(client):
     doc_id = 3273551
     external_id = "11.14#I1.i1.p1"
-    partner_name = "DLMF"
+    partner_name = "dlmf"
 
     de_val = target_helpers.get_de_from_input(doc_id)
 
@@ -331,7 +331,7 @@ def test_patch_link_with_new_source(client):
 def test_patch_link_with_new_title(client):
     doc_id = 3273551
     external_id = "11.14#I1.i1.p1"
-    partner_name = "DLMF"
+    partner_name = "dlmf"
 
     json_base = {arg_names["document"]: doc_id,
                  arg_names["link_ext_id"]: external_id,
@@ -360,7 +360,7 @@ def test_patch_link_with_new_title(client):
 def test_post_then_delete_link(client):
     document = 2062129
     external_id = "11.14#I1.i1.p1"
-    partner_name = "DLMF"
+    partner_name = "dlmf"
 
     link_query = Link.query.filter_by(document=document,
                                       external_id=external_id,
@@ -391,7 +391,7 @@ def test_post_then_delete_link(client):
 def test_post_existing_link(client):
     document = 3273551
     external_id = "11.14#I1.i1.p1"
-    partner_name = "DLMF"
+    partner_name = "dlmf"
 
     link_query = Link.query.filter_by(document=document,
                                       external_id=external_id,
@@ -419,7 +419,7 @@ def test_post_existing_link(client):
 def test_empty_patch(client):
     document = 3273551
     external_id = "11.14#I1.i1.p1"
-    partner_name = "DLMF"
+    partner_name = "dlmf"
 
     link_query = Link.query.filter_by(document=document,
                                       external_id=external_id,

--- a/tests/api/link/partner_test.py
+++ b/tests/api/link/partner_test.py
@@ -29,7 +29,7 @@ def test_put_partner(client):
     response = client.get("/links_api/partner/")
     data = response.json
     name: dict = data[0].get("name")
-    assert test_name == name
+    assert test_name.lower() == name
 
 
 def test_put_partner_full(client):

--- a/tests/api/link/partner_test.py
+++ b/tests/api/link/partner_test.py
@@ -9,7 +9,7 @@ def test_get_partner(client):
     data = response.json
     assert len(data) == 1
     entry: dict = data[0]
-    assert len(entry.keys()) == 3
+    assert len(entry.keys()) == 4
     url: dict = entry.get("url")
     assert "https" in url
 

--- a/tests/api/link/source_helpers_test.py
+++ b/tests/api/link/source_helpers_test.py
@@ -5,7 +5,7 @@ from zb_links.db.models import Source, db
 
 def test_new_source_with_title():
     source_val = "26.8#vii.p4"
-    source_name = "DLMF"
+    source_name = "dlmf"
     title_name = "my cool title"
 
     response = create_new_source(source_val, source_name, title_name)
@@ -21,7 +21,7 @@ def test_new_source_with_title():
 
 def test_new_source_wout_title():
     source_val = "26.8#vii.p4"
-    source_name = "DLMF"
+    source_name = "dlmf"
 
     response = create_new_source(source_val, source_name)
     assert not response


### PR DESCRIPTION
follows the solution outlined in redmine ticket number 6126.
partner model is altered to contain a new 'display_name' column.  Entries for doc_ext_id.type and source.partner should be in lowercase. 

user input for partner is converted to lowercase (in case of patch partner, the input of a new name is used as the display_name entry).