### PR TITLE
Feat/scholix fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ One can use [dotenv](https://pypi.org/project/python-dotenv/) to store your sett
 
 a) In what follows links are objects belonging to the `source` (within a given partner) and zbMATH objects are objects belonging to the `target` [zbMATH](https://zbmath.org/).
 
-b) The zbMATH Links API offers 11 endpoints.
+b) The zbMATH Links API offers 12 endpoints.
 
 1. GET/link. It retrieves links for given zbMATH objects.
 
@@ -128,11 +128,13 @@ b) The zbMATH Links API offers 11 endpoints.
 
 8. PUT/partner. It edits data of a given zbMATH partner.
 
-9. GET/source. It produces a list of all links of a given zbMATH partner.
+9. POST/partner. It creates a new partner related to zbMATH.
 
-10. GET/statistics/msc. It shows the occurrence of primary MSC codes (2-digit level) of zbMATH objects in the set of links of a given partner.
+10. GET/source. It produces a list of all links of a given zbMATH partner.
 
-11. GET/statistics/year. It shows the occurrence of years of publication of zbMATH objects in the set of links of a given partner.
+11. GET/statistics/msc. It shows the occurrence of primary MSC codes (2-digit level) of zbMATH objects in the set of links of a given partner.
+
+12. GET/statistics/year. It shows the occurrence of years of publication of zbMATH objects in the set of links of a given partner.
 
 c) The X-Field is an optional parameter that can be used when one is running a query that can pull back a lot of metadata, but only a few fields in the output are of interest. Example: in the GET/link one is interested only in retrieving the id identifier of sources where the name of the author is Abramowitz.
 Then, Author: Abramowitz, X-Field: {Source{Identifier{ID}}}.

--- a/src/zb_links/api/link/display.py
+++ b/src/zb_links/api/link/display.py
@@ -68,13 +68,13 @@ target = api.model(
     {
         "Identifier": fields.Nested(object_id_info),
         "Type": fields.Nested(name_model),
-        "Title": fields.String(description="title of the publication"),
-        "Creator": fields.List(fields.Nested(name_model_creator)),
+        # "Title": fields.String(description="title of the publication"),
+        # "Creator": fields.List(fields.Nested(name_model_creator)),
         "PublicationDate": fields.Integer(description="year of publication"),
-        "Publisher": fields.String(
-            required=True,
-            description="publisher of book or journal name of publication",
-        ),
+        # "Publisher": fields.String(
+        #     required=True,
+        #     description="publisher of book or journal name of publication",
+        # ),
     },
 )
 
@@ -110,7 +110,7 @@ def get_display(link_element):
     element_target = link_element.document
     element_link_publication_date = link_element.matched_at
     element_link_provider = link_element.created_by
-    element_relationship_type = None
+    element_relationship_type = "isRelatedTo"
 
     partner_id = link_element.type
     partner_obj = Partner.query.get(partner_id)
@@ -165,6 +165,7 @@ def get_display(link_element):
     provider_id_dict = {
         "ID": element_link_provider,
         "IDScheme": "zbMATH scheme",
+        "IDURL": "https://zbmath.org/"
     }
     provider_dict = {
         "identifier": marshal(provider_id_dict, object_id_info),

--- a/src/zb_links/api/link/display.py
+++ b/src/zb_links/api/link/display.py
@@ -165,7 +165,7 @@ def get_display(link_element):
     provider_id_dict = {
         "ID": element_link_provider,
         "IDScheme": "zbMATH scheme",
-        "IDURL": "https://zbmath.org/"
+        "IDURL": "https://zbmath.org/",
     }
     provider_dict = {
         "identifier": marshal(provider_id_dict, object_id_info),

--- a/tests/api/link/links_test.py
+++ b/tests/api/link/links_test.py
@@ -65,7 +65,7 @@ def test_get_link_msc(client):
     response = client.get(f"/links_api/link/?{param}")
     data = response.json
     assert len(data) > 0
-    assert data[0]["RelationshipType"] == "isRelatedTo"
+    # assert data[0]["RelationshipType"] == "isRelatedTo"
 
 
 def test_post_link(client):

--- a/tests/api/link/links_test.py
+++ b/tests/api/link/links_test.py
@@ -65,7 +65,7 @@ def test_get_link_msc(client):
     response = client.get(f"/links_api/link/?{param}")
     data = response.json
     assert len(data) > 0
-    assert not data[0]["RelationshipType"]
+    assert data[0]["RelationshipType"] == "isRelatedTo"
 
 
 def test_post_link(client):


### PR DESCRIPTION
Task #6250 (https://donald.zentralblatt-math.org/redmine/issues/6250) part 4).
This fixes the displayed json output, now compatible with the Scholix schema. In particular "Creator" and "title" were "null" in the previous version. They have been removed since optional in Scholix.